### PR TITLE
Add Listener feature to the drawing controller when drawing is end

### DIFF
--- a/lib/src/drawing_controller.dart
+++ b/lib/src/drawing_controller.dart
@@ -131,7 +131,7 @@ class DrawConfig {
 }
 
 /// 绘制控制器
-class DrawingController {
+class DrawingController extends ChangeNotifier {
   DrawingController({
     DrawConfig? config,
     PaintContent? content,
@@ -310,6 +310,7 @@ class DrawingController {
 
     _refresh();
     _refreshDeep();
+    notifyListeners();
   }
 
   /// 撤销


### PR DESCRIPTION
This pull request is regarding the issue [Add Listener Feature](https://github.com/fluttercandies/flutter_drawing_board/issues/27)

Added Feature: Support Listener feature on drawing end