### PR TITLE
fix: added notifyListeners for undo/redo for DrawingController

### DIFF
--- a/lib/src/drawing_controller.dart
+++ b/lib/src/drawing_controller.dart
@@ -361,6 +361,7 @@ class DrawingController extends ChangeNotifier {
     if (_currentIndex > 0) {
       _currentIndex = _currentIndex - 1;
       _refreshDeep();
+      notifyListeners();
     }
   }
 
@@ -380,6 +381,7 @@ class DrawingController extends ChangeNotifier {
     if (_currentIndex < _history.length) {
       _currentIndex = _currentIndex + 1;
       _refreshDeep();
+      notifyListeners();
     }
   }
 


### PR DESCRIPTION
Currently, the undo and redo operations do not notify listeners to the DrawingController.