### PR TITLE
Ability to control available actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pubspec.lock
 .pub-cache/
 .pub/
 build/
+.vscode/
 
 # Android related
 **/android/**/gradle-wrapper.jar
@@ -73,3 +74,7 @@ build/
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
+
+# FVM Version Cache
+.fvm/
+.fvmrc

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -43,3 +43,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+.cxx/

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -380,6 +380,13 @@ class _MyHomePageState extends State<MyHomePage> {
                       ),
                       showDefaultActions: true,
                       showDefaultTools: true,
+                      defaultActionItems: [
+                        DefActionItem.Stroke,
+                        DefActionItem.Undo,
+                        DefActionItem.Redo,
+                        DefActionItem.Rotate,
+                        DefActionItem.Clear,
+                      ],
                       defaultToolsBuilder: (Type t, _) {
                         return DrawingBoard.defaultTools(t, _drawingController)
                           ..insert(

--- a/lib/src/drawing_board.dart
+++ b/lib/src/drawing_board.dart
@@ -33,6 +33,13 @@ class DrawingBoard extends StatefulWidget {
     this.onPointerUp,
     this.clipBehavior = Clip.antiAlias,
     this.defaultToolsBuilder,
+    this.defaultActionItems = const <DefActionItem>[
+      DefActionItem.Stroke,
+      DefActionItem.Undo,
+      DefActionItem.Redo,
+      DefActionItem.Rotate,
+      DefActionItem.Clear,
+    ],
     this.boardClipBehavior = Clip.hardEdge,
     this.panAxis = PanAxis.free,
     this.boardBoundaryMargin,
@@ -75,6 +82,8 @@ class DrawingBoard extends StatefulWidget {
 
   /// 默认工具栏构建器
   final DefaultToolsBuilder? defaultToolsBuilder;
+
+  final List<DefActionItem> defaultActionItems;
 
   /// 缩放板属性
   final Clip boardClipBehavior;
@@ -173,7 +182,11 @@ class _DrawingBoardState extends State<DrawingBoard> {
       content = Column(
         children: <Widget>[
           Expanded(child: content),
-          if (widget.showDefaultActions) buildDefaultActions(_controller),
+          if (widget.showDefaultActions)
+            buildDefaultActions(
+              _controller,
+              defaultActionItems: widget.defaultActionItems,
+            ),
           if (widget.showDefaultTools)
             buildDefaultTools(_controller,
                 defaultToolsBuilder: widget.defaultToolsBuilder),
@@ -252,7 +265,10 @@ class _DrawingBoardState extends State<DrawingBoard> {
   }
 
   /// 构建默认操作栏
-  static Widget buildDefaultActions(DrawingController controller) {
+  static Widget buildDefaultActions(
+    DrawingController controller, {
+    List<DefActionItem> defaultActionItems = const <DefActionItem>[],
+  }) {
     return Material(
       color: Colors.white,
       child: SingleChildScrollView(
@@ -262,40 +278,48 @@ class _DrawingBoardState extends State<DrawingBoard> {
             valueListenable: controller.drawConfig,
             builder: (_, DrawConfig dc, ___) {
               return Row(
-                children: <Widget>[
-                  SizedBox(
-                    height: 24,
-                    width: 160,
-                    child: Slider(
-                      value: dc.strokeWidth,
-                      max: 50,
-                      min: 1,
-                      onChanged: (double v) =>
-                          controller.setStyle(strokeWidth: v),
-                    ),
-                  ),
-                  IconButton(
-                    icon: Icon(
-                      CupertinoIcons.arrow_turn_up_left,
-                      color: controller.canUndo() ? null : Colors.grey,
-                    ),
-                    onPressed: () => controller.undo(),
-                  ),
-                  IconButton(
-                    icon: Icon(
-                      CupertinoIcons.arrow_turn_up_right,
-                      color: controller.canRedo() ? null : Colors.grey,
-                    ),
-                    onPressed: () => controller.redo(),
-                  ),
-                  IconButton(
-                      icon: const Icon(CupertinoIcons.rotate_right),
-                      onPressed: () => controller.turn()),
-                  IconButton(
-                    icon: const Icon(CupertinoIcons.trash),
-                    onPressed: () => controller.clear(),
-                  ),
-                ],
+                children: defaultActionItems.map((DefActionItem item) {
+                  switch (item) {
+                    case DefActionItem.Stroke:
+                      return SizedBox(
+                        height: 24,
+                        width: 160,
+                        child: Slider(
+                          value: dc.strokeWidth,
+                          max: 50,
+                          min: 1,
+                          onChanged: (double v) =>
+                              controller.setStyle(strokeWidth: v),
+                        ),
+                      );
+                    case DefActionItem.Undo:
+                      return IconButton(
+                        icon: Icon(
+                          CupertinoIcons.arrow_turn_up_left,
+                          color: controller.canUndo() ? null : Colors.grey,
+                        ),
+                        onPressed: () => controller.undo(),
+                      );
+                    case DefActionItem.Redo:
+                      return IconButton(
+                        icon: Icon(
+                          CupertinoIcons.arrow_turn_up_right,
+                          color: controller.canRedo() ? null : Colors.grey,
+                        ),
+                        onPressed: () => controller.redo(),
+                      );
+                    case DefActionItem.Rotate:
+                      return IconButton(
+                        icon: const Icon(CupertinoIcons.rotate_right),
+                        onPressed: () => controller.turn(),
+                      );
+                    case DefActionItem.Clear:
+                      return IconButton(
+                        icon: const Icon(CupertinoIcons.trash),
+                        onPressed: () => controller.clear(),
+                      );
+                  }
+                }).toList(),
               );
             }),
       ),
@@ -376,3 +400,5 @@ class _DefToolItemWidget extends StatelessWidget {
     );
   }
 }
+
+enum DefActionItem { Stroke, Undo, Redo, Rotate, Clear }


### PR DESCRIPTION
With the introduction of a new enum **DefActionItem** and a new parameter **defaultActionItems**, on the **DrawingBoard** class, you can now specify which action items to display and in what order.

By default, all are displayed in the default order.


An example of removing the rotate action and putting the Stroke changer action last.
![image](https://github.com/user-attachments/assets/252e9c46-52f0-46ab-b254-97d46f025242)


Should resolve [this issue](https://github.com/fluttercandies/flutter_drawing_board/issues/60)
